### PR TITLE
Fixed chunked encoding error

### DIFF
--- a/lib/proxy.ex
+++ b/lib/proxy.ex
@@ -48,7 +48,7 @@ defmodule Proxy do
     # if it is chunked or not and act accordingly to support streaming.
     #
     # We may also need to delete other headers in a proxy.
-    headers = List.keydelete(headers, "Transfer-Encoding", 1)
+    headers = List.keydelete(headers, "Transfer-Encoding", 0)
 
     %{conn | resp_headers: headers}
     |> send_resp(status, body)


### PR DESCRIPTION
The `Transfer-Encoding` header was not deleted since it is at 0 position and not 1. Hence errors were thrown for any proxy response with `chunked` encoding